### PR TITLE
Rename RSSlink to RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,4 +10,4 @@
 <link rel="shortcut icon" href="/favicon.ico">
 
 <!-- RSS -->
-<link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,7 +13,7 @@
       </li>
       {{end}}
   
-      <li class="pull-right"><a href="{{ .RSSlink }}"><i class="fa fa-rss"></i></a></li>
+      <li class="pull-right"><a href="{{ .RSSLink }}"><i class="fa fa-rss"></i></a></li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
The former will be deprecated and eventually removed from Hugo.

Note: Currently both of them exist in Hugo, which is the reason for the cleanup.