### PR TITLE
updated readme with a quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ git clone https://github.com/IvanChou/hugo-theme-vec vec
 
 See the [official docs](http://gohugo.io/themes/installing) for more information.
 
+## Quickstart Guide
+
+Make sure you have : 
+
+1. 	Hugo installed
+2. Test poject setup with hugo. Instructions on [hugo quickstart guide](https://gohugo.io/overview/quickstart/).
+3. Cloned this repo in the themes folder.  
+
+The [exampleSite](exampleSite) folder contains a sample site to quickly get started. 
+
+Copy over the contents of ```config.toml``` and copy the [content](exampleSite/content) and [static](exampleSite/static) folders to your main folder. 
+
+Build using ```hugo server --buildDrafts```  
+
+To create a post use ```hugo new post/post-title.md``` 
+
 ## Configuration
 
 You should config your site's `config.toml` file like:


### PR DESCRIPTION
Hi,

I added a quick start guide in the readme. After cloning and modifying  my ```config.toml``` I had trouble figuring out how to how to get started and adding new posts (example : is it post or blog?)

Most users familiar with hugo won't have issues and this is a theme repo, so these instructions might not belong here. I felt they might be helpful. 

BTW thanks for the nice theme! 